### PR TITLE
Support Path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ Download the `exercism` CLI by following [the official guide](https://exercism.o
 
 https://user-images.githubusercontent.com/15933322/190892930-2ff737ae-f672-4688-ab0d-7f655508da77.mov
 
+### `Path Configuration`
+Before customizing `exercism--workspace`, be sure to change it on the CLI first:
+
+```bash
+exercism -w "path/to/dir"
+```
+#### [no-littering](https://github.com/emacscollective/no-littering)
+Users of this package can "theme" the directory of this package rather simply:
+
+```emacs-lisp
+(setq (exercism--workspace (no-littering-expand-var-file-name "exercism/")))
+```
+
+This sets the workspace to the var directory inside your emacs folder.
+
 ## `Set current track`
   - Choose the track that you want to do exercises for.
   - This might take a few minutes the first time because it "initializes" the track locally. Subsequent invocations will be instant.

--- a/exercism.el
+++ b/exercism.el
@@ -354,7 +354,7 @@ Turn '3.26.1' into something like: 3_026_001."
   (interactive)
   (let* ((version (await (exercism--cli-version)))
          (min-version "3.2.0")
-         (track-dir (expand-file-name exercism--current-track exercism-directory))
+         (track-dir (expand-file-name exercism--current-track exercism--workspace))
          (exercise-dir (expand-file-name exercism--current-exercise track-dir))
          ;; TODO Maybe use a macro that sets the dir? e.g. (with-current-track ...)
          (default-directory exercise-dir)


### PR DESCRIPTION
This PR adds instructions on customizing exercism's path, including support for [no-littering](https://github.com/emacscollective/no-littering). Also, fix a reference to a deprecated function (I also recommend you to look into `define-obsolete-variable-alias`).